### PR TITLE
🚀 fix: Force Kafka scale-down to 1 replica

### DIFF
--- a/k8s/platform/confluent/templates/kafka.yaml
+++ b/k8s/platform/confluent/templates/kafka.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: confluent
 spec:
   replicas: 1
+  configOverrides:
+    server:
+      - "default.replication.factor=1"
+      - "offsets.topic.replication.factor=1"
+      - "transaction.state.log.replication.factor=1"
+      - "transaction.state.log.min.isr=1"
+      - "min.insync.replicas=1"
   image:
     application: confluentinc/cp-kafka:7.5.0
     init: confluentinc/confluent-init-container:2.7.0


### PR DESCRIPTION
## Summary
🚀 This PR forces the Confluent Operator to scale down Kafka to 1 replica by overriding the replication factor and min-ISR settings.

## Changes
- 📉 **Force Scale-Down**: Added `configOverrides` to force `default.replication.factor=1`, `min.insync.replicas=1`, and other relevant settings.
- 📦 **Replicas**: Maintained `replicas: 1` as the target configuration.