### PR TITLE
🐛 fix(clickhouse): pin keeper to wayne node

### DIFF
--- a/k8s/platform/clickhouse/templates/keeper.yaml
+++ b/k8s/platform/clickhouse/templates/keeper.yaml
@@ -5,6 +5,9 @@ metadata:
   name: keeper
 spec:
   replicas: 1
+  podTemplate:
+    nodeSelector:
+      kubernetes.io/hostname: wayne
   dataVolumeClaimSpec:
     resources:
       requests:


### PR DESCRIPTION
## Summary
This PR pins the single-replica ClickHouse Keeper to node `wayne` to resolve volume attachment issues when the pod reschedules.

## Details
- **What was changed**: Added `spec.podTemplate.nodeSelector` pointing to node `wayne` in `k8s/platform/clickhouse/templates/keeper.yaml`.
- **Why it was changed**: ClickHouse Keeper runs as a single-replica StatefulSet. When rescheduling to different nodes, the Longhorn volume (RWO) was getting stuck on the previous node (`monarch`), preventing the pod from attaching the volume on the new node (`wayne`) and leaving the pod in `ContainerCreating` state. Pinning the pod to `wayne` ensures it does not attempt to reschedule to different nodes.
- **Verification steps**:
  - Validated YAML syntax locally.
  - Committing and creating PR.