### PR TITLE
🚨 chore(yaml): resolve yamllint errors and warnings

### DIFF
--- a/k8s/apps/adguard-home/values.yaml
+++ b/k8s/apps/adguard-home/values.yaml
@@ -17,14 +17,6 @@ app-template:
                   values:
                     - adguard-home
             topologyKey: "kubernetes.io/hostname"
-      # nodeAffinity:
-      #   requiredDuringSchedulingIgnoredDuringExecution:
-      #     nodeSelectorTerms:
-      #       - matchExpressions:
-      #           - key: node-role.kubernetes.io/control-plane #node-role.kubernetes.io/master
-      #             operator: In
-      #             values:
-      #               - "true"
 
   controllers:
     main:

--- a/k8s/apps/immich/values.yaml
+++ b/k8s/apps/immich/values.yaml
@@ -27,7 +27,7 @@ immich:
   immich:
     metrics:
       enabled: true
-      
+
   server:
     controllers:
       main:

--- a/k8s/apps/paperless-ngx/values.yaml
+++ b/k8s/apps/paperless-ngx/values.yaml
@@ -99,7 +99,7 @@ app-template:
       ports:
         http:
           port: 3000
-          
+
   persistence:
     pg-data:
       enabled: true

--- a/k8s/apps/upsnap/values.yaml
+++ b/k8s/apps/upsnap/values.yaml
@@ -15,12 +15,7 @@ app-template:
             tag: 5.4.0
           env:
             TZ: "America/Los_Angeles"
-            UPSNAP_SCAN_RANGE: 192.168.10.0/24 # Scan range is used for device discovery on local network
-          # securityContext:
-          #   capabilities:
-          #     add:
-          #       - NET_ADMIN
-          #       - NET_RAW
+            UPSNAP_SCAN_RANGE: 192.168.10.0/24  # Scan range is used for device discovery on local network
 
   service:
     upsnap:


### PR DESCRIPTION
## Summary
This PR resolves several yamllint errors and warnings across four `values.yaml` files.

## Details
- **immich**: Removed trailing whitespace and ensured there is a newline at the end of the file.
- **adguard-home**: Cleaned up stale, commented-out `nodeAffinity` code which was triggering comments-indentation warnings.
- **upsnap**: Fixed inline comment spacing and removed unused, commented-out `securityContext` code triggering comments-indentation warnings.
- **paperless-ngx**: Removed trailing whitespace.

## Verification
- Ran `yamllint` locally on the modified files to verify they are all free of errors and warnings.