### PR TITLE
🐛 fix(traefik): fix case sensitivity for timeouts in additionalArguments

### DIFF
--- a/metal/roles/k3s/files/traefik-config.yaml
+++ b/metal/roles/k3s/files/traefik-config.yaml
@@ -25,5 +25,5 @@ spec:
     additionalArguments:
       - --entryPoints.web.transport.respondingTimeouts.readTimeout=0s
       - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=0s
-      - --entryPoints.websecure.transport.respondingTimeouts.writetimeout=0s
-      - --entryPoints.websecure.transport.respondingTimeouts.idletimeout=600s
+      - --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=0s
+      - --entryPoints.websecure.transport.respondingTimeouts.idleTimeout=600s


### PR DESCRIPTION
## Summary
Fix case sensitivity for Traefik respondingTimeouts CLI arguments (`writeTimeout` and `idleTimeout`).

## Details
- **What was changed**: Corrected `--entryPoints.websecure.transport.respondingTimeouts.writetimeout` -> `writeTimeout` and `.idletimeout` -> `idleTimeout` in `metal/roles/k3s/files/traefik-config.yaml`.
- **Why it was changed**: Traefik's static configuration CLI argument parser is case-sensitive. The lowercase options (`writetimeout` and `idletimeout`) were being silently ignored.
- **Verification steps**:
  - Applied the manifest directly to the cluster.
  - Inspected the container arguments of the upgraded Traefik pod and confirmed they now correctly propagate:
    ```
    --entryPoints.websecure.transport.respondingTimeouts.writeTimeout=0s
    --entryPoints.websecure.transport.respondingTimeouts.idleTimeout=600s
    ```