### PR TITLE
✨ feat(traefik): add 10gb body limit middleware

### DIFF
--- a/metal/roles/k3s/files/traefik-middlewares.yaml
+++ b/metal/roles/k3s/files/traefik-middlewares.yaml
@@ -7,3 +7,12 @@ metadata:
 spec:
   buffering:
     maxRequestBodyBytes: 25165824 # 24MiB
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: body-limit-10gb
+  namespace: kube-system
+spec:
+  buffering:
+    maxRequestBodyBytes: 10737418240 # 10GB


### PR DESCRIPTION
## Summary
Add a new 10GB request body limit Traefik Middleware (`body-limit-10gb`).

## Details
- **What was changed**: Added a new Traefik Middleware `body-limit-10gb` in `metal/roles/k3s/files/traefik-middlewares.yaml`.
- **Why it was changed**: To support large file uploads/requests (up to 10GB) in applications that require high limits (such as Immich).
- **Verification steps**:
  - Applied the manifest directly to the cluster.
  - Inspected the middleware list to confirm it was created successfully.