### PR TITLE
✨ feat(apps): apply 10gb body limit and replica updates to immich and koffan

### DIFF
--- a/k8s/apps/immich/secrets.yaml
+++ b/k8s/apps/immich/secrets.yaml
@@ -4,110 +4,111 @@ app-template:
             containers:
                 main:
                     env:
-                        API_URL: ENC[AES256_GCM,data:N2oSEH1C5kBtLphIr7t0TObGU1VfXFpz2yIdqmUgu53fS2/HKocBLg==,iv:yl9uXClBSnqMfv3e2D8IPJea7z15sogzfVaW1kmzd4A=,tag:CcnewJvIc+YSepJSgmgMLw==,type:str]
-                        API_KEY: ENC[AES256_GCM,data:AuPhCgv4eGMi5+ErgZ39Or/k9vdXjcJBOnVtS2nRPgT3ZqlTKg1rNwdm,iv:158CtqbpR45XnL0m9rhJ3ur39IT7a6+oXQddidE77rI=,tag:BZO3EtpJyu87lGZLvU5ueQ==,type:str]
-                        ROOT_PATH: ENC[AES256_GCM,data:MqRLpcLWuTEDdVLWNgPe6a8=,iv:yOHRKpNDqlRr7TsamoGJBXcfbaH69r/r8l6usJFH0y4=,tag:DDMpGyIqZX5thwDfmZ60Eg==,type:str]
-                        CRON_EXPRESSION: ENC[AES256_GCM,data:q0AMfd2Uj+LX,iv:cD25FcEl7+8g8SVnm6D8Kb0NcmaTSSgwZ3dvvIuyzNs=,tag:3xkXCRrFq9KEc5A032AENA==,type:str]
-                        TZ: ENC[AES256_GCM,data:MqfnsRGNVr3gjCIj66yNJhzkWQ==,iv:6S5NGc1wB/gdGNt3AMNUBXBPLyDBj418xIpC7uDVtEY=,tag:XEmWS+UsWq7CX7cF7saGzw==,type:str]
-                        ALBUM_LEVELS: ENC[AES256_GCM,data:NQ==,iv:ZxhUEBWuHpX+A6QjsnThFpFemzRzwOpZNJ9lvve/Xvw=,tag:FHyTnNvZgV0ruhWXiX/YWQ==,type:str]
-                        RUN_IMMEDIATELY: ENC[AES256_GCM,data:m7O0xg==,iv:yp5enMYGJWZMt3DpcwK/RXi5Wnp8HAXHt3YJ1mWVAxg=,tag:w64EFXbyfKs7OKEfaVG+Ow==,type:str]
-                        ALBUM_SEPARATOR: ENC[AES256_GCM,data:mUtc,iv:HPGFmuLWYh3P1u04v2r01IBOtUzpzEfyFBEbKhnPQF0=,tag:oD3jbybUgqrTNWdki3b3wg==,type:str]
+                        API_URL: ENC[AES256_GCM,data:2HIXXS17xcP+u4R5GlAsD4cTb6FavosWWBpCjSsRiJQyKL3BB1uBgA==,iv:lWPzY/oq72/kLijUC7fJHl9suHHDOSnYnf8NxbSzqEA=,tag:fq3EkgRc2Rw+LA787bL73g==,type:str]
+                        API_KEY: ENC[AES256_GCM,data:TRqvYssTgJsAe9PpAmzs7CCzVuBOx3qpvONB58WiFrLPoi3XN0WGJHoe,iv:4aLNQV/yFIqvxsSWy5M5yEd2Z/29UNKIQqF59Pwu5KQ=,tag:FqXWlNl3cE+z0KhmMJLhYw==,type:str]
+                        ROOT_PATH: ENC[AES256_GCM,data:UepAmQOB4HP0+1XeAAc3A+s=,iv:Nmw5riwWy9G6qYLUxRWjJLSHj79KeSe5qXh1O3zkfMs=,tag:BsP9zHoa5wEpqBfnS9VIAw==,type:str]
+                        CRON_EXPRESSION: ENC[AES256_GCM,data:jiTnc5RO3WqY,iv:ype6r/Yb8yVN3ic7091V9cfTF9Jc3eolm+CaEsu8VXU=,tag:VigKsbKczo+dyzC0gurpGg==,type:str]
+                        TZ: ENC[AES256_GCM,data:C7pJ91wMTM0XcuaCvYtZ2OGirA==,iv:RpWJTD9VrSpoc+oc18RJT18pUSiwUqQ9+oAUTLi66s4=,tag:nBRkHscNEPvjCXCo6E1NMg==,type:str]
+                        ALBUM_LEVELS: ENC[AES256_GCM,data:7w==,iv:jaVglDLa1m8phttOKuhHsButk4gyFHD889QVVpZ5JOE=,tag:BwfPDnevk9uNFc1cVJu/Sw==,type:str]
+                        RUN_IMMEDIATELY: ENC[AES256_GCM,data:pTivGA==,iv:lmhEnfceqiYSK3JwTuGjEwSA3Xm7YUDMaz4/yKfwTrQ=,tag:7joThJW5f9PiRIZ8pOZ/ag==,type:str]
+                        ALBUM_SEPARATOR: ENC[AES256_GCM,data:U0k+,iv:ObFij6+AVh+zxMwWaCaDoCV9KGhKWLRqezTl3jwtdqk=,tag:HJ3kPoarMvIH9Yw0qmPpiA==,type:str]
 immich:
     controllers:
         main:
             containers:
                 main:
                     env:
-                        TZ: ENC[AES256_GCM,data:VE3AOw8sZIrEGF2BFFKn9Kh2WA==,iv:KFMeLVyCOcf6kaGxzX754J7lSGSnwkyOSH7e4GoyujA=,tag:qDbYIVnJ97GBBSQPTsjRLQ==,type:str]
+                        TZ: ENC[AES256_GCM,data:fZCoGGNCcG3IwLpdKuMnPePflg==,iv:1D0/YRGkt+XSTDM49YzqGN5hl0neu/XDViNxNuY3Nn8=,tag:CwO0sFpXOWLlrQ2gaAWUyw==,type:str]
                         DB_HOSTNAME:
                             valueFrom:
                                 secretKeyRef:
-                                    name: ENC[AES256_GCM,data:2VbVIZQmtTXZlr84nk0lwBtPJg==,iv:Yb9u8Enakak5XU3RbtsSJ3N5Pf+SuXerZ5NQ619NvBM=,tag:+OLJEsbe9EaT40ZOhsi3rA==,type:str]
-                                    key: ENC[AES256_GCM,data:wQdMfA==,iv:eh6qikUIu6HL4RSMANhxG1luPxC7XT2D125BkiaRpD0=,tag:6AcZrRZh4/hW5ub3ULhvjw==,type:str]
+                                    name: ENC[AES256_GCM,data:ZNXYUg5sJjectvitW51HDiSInA==,iv:xOZdhFQaBrCooMDJPxMDwaDA3jU+r3mZUW8RUDLEPI4=,tag:UMP9Ql4JgwNeutv7Sxyneg==,type:str]
+                                    key: ENC[AES256_GCM,data:BtCR7w==,iv:7z76DC/akQZrYRXahqIpktybmmxJWQcqcOq8vjAVguE=,tag:3+fy3meQ0bo3Qz3JR4SpLQ==,type:str]
                         DB_USERNAME:
                             valueFrom:
                                 secretKeyRef:
-                                    name: ENC[AES256_GCM,data:TkbplPiZ2o1KbuLQafXs0mbxxA==,iv:aQrFqi8mcxvjST+sUDYqtXDLPqK9cWH933mLHx1puCk=,tag:1MO3hw5LV/AY6g8Le3g8wA==,type:str]
-                                    key: ENC[AES256_GCM,data:5jPu+w==,iv:cHm4wMeIBAijZ6UGB6Eqj8mkA+kMjRidfGERShWekcs=,tag:uhtVzCJLKdG9CxUHon/l0g==,type:str]
+                                    name: ENC[AES256_GCM,data:1cVuJ4Z0iwRSq78Qn/QFr/jZnA==,iv:woR+RE8lwzAIBWpEYntrwPJfRJNbBjiO7lAo+UlaPL8=,tag:2o62IEsaqcXURfX3P/Eh5w==,type:str]
+                                    key: ENC[AES256_GCM,data:CMzNZA==,iv:TkkmSV+Ds8C20aBNN6d3YQoWs4zkUl7BGhAmm7qbd70=,tag:QtKfOCCjfdcRKaUXIKrAJg==,type:str]
                         DB_PASSWORD:
                             valueFrom:
                                 secretKeyRef:
-                                    name: ENC[AES256_GCM,data:/8ntaZUyvzyBwSwOEnr7ob48eQ==,iv:WMNrAI09JfEFCWWChELhOyhE9QtQSSssm2w8jWr5ibU=,tag:Vb+cEdAUy/MU9l1Z0RQtYQ==,type:str]
-                                    key: ENC[AES256_GCM,data:YAjp7E04CyM=,iv:DC+kmHx6i9qtx1OceP8ORaZCQqUwnvmpBg9sjpjJcm4=,tag:9du8VtH4JoHVeXHTixb5Bg==,type:str]
+                                    name: ENC[AES256_GCM,data:pUedUV7JoBlfafSbVaKIeit8OQ==,iv:+H3dvgcLiRGdwGDMg4cxZ5A/UeVoya0YqnLuyKlnygk=,tag:VFnDVL5yYVG5v8Ee0rD3jA==,type:str]
+                                    key: ENC[AES256_GCM,data:eFabMaG8OnI=,iv:zRJRdF1Qu+H8XtaLm2e35l7lL/EtFf19LqWR4poZB6Q=,tag:RNpyfcOlrSTSr+KLuUE4Vg==,type:str]
                         DB_DATABASE_NAME:
                             valueFrom:
                                 secretKeyRef:
-                                    name: ENC[AES256_GCM,data:cGfVdSnlQoLSn/0myfrq55ipTA==,iv:H66j8sRwM2zSE3INA4tMIlUfQ/1QmuN+mXzl/ZysSu0=,tag:NdiPMFYKZmOwleFwN2ybIA==,type:str]
-                                    key: ENC[AES256_GCM,data:1dTU5oHZ,iv:0YMQ6mNZRtYX8Q/FyTArMwsyWirU8MuqPgfG4o3Ck9M=,tag:Cf0BDG7J/WUmuNi9Ik3VTA==,type:str]
+                                    name: ENC[AES256_GCM,data:LZ2rMSdBln6pclah1jG+/6rGzg==,iv:lJMRcrNgXdNC8gVuknp8PR3klkLmNcsIMiYeGo0sSN4=,tag:uLDOVWJAsfYUnw5E4GcRLg==,type:str]
+                                    key: ENC[AES256_GCM,data:NcB1i1Pt,iv:BVNid6fZ2H9+9+0Uq/g5vWPZm5mnGUTHpA//oheKy9k=,tag:zBWr3IRirFwExxt0si2C2A==,type:str]
     immich:
         configuration:
             server:
-                externalDomain: ENC[AES256_GCM,data:tXB2IZxf7bjITyDZj5wr0rDoUkYGOoLmR5Y=,iv:MXDEXq+b4XUwlmRlDzsiTIdGukD/NQXHjdRyFxtJThw=,tag:tdUYf1Z+nzbY1ZQHSeLNQA==,type:str]
-                publicUsers: ENC[AES256_GCM,data:NbiXkZ8=,iv:sBJMONEqFeYA01bFTGMlNpdBNs2YwEFFs1a2HHzpbQw=,tag:NOluemws3AYSLRpLErmWnw==,type:bool]
+                externalDomain: ENC[AES256_GCM,data:NtTlAB4NqCfgDC4oioUFlxbjX+4/kzYuQts=,iv:Fta8EYOBJzySochTfwk5yoZbOVD1fybsgzPJ6akbgx8=,tag:07B4PSLtxor37cOieyeWXA==,type:str]
+                publicUsers: ENC[AES256_GCM,data:RhM3B/U=,iv:YzLJZ50oVxUZOm30fQb2quck0745nRMd0519S+8tf1s=,tag:6LEOKXzBO3JGs4M2gyGmFQ==,type:bool]
             passwordLogin:
-                enabled: ENC[AES256_GCM,data:adkQcw==,iv:lf1IOB/+RtVnC59Kj1Juxt91EtEetTPap2FQaVZFvYk=,tag:lbB99OdnrozhRY0XblrXzA==,type:bool]
+                enabled: ENC[AES256_GCM,data:YfEN3A==,iv:fT/dQ1fdQjNsvOkGn8GaM7VjZL85n6OYyQScyUelCEs=,tag:ETsz9R+0Bl3u5L478t3tTw==,type:bool]
             storageTemplate:
-                enabled: ENC[AES256_GCM,data:MHF3LQ==,iv:nLprA11Z2aeQwWKvWQNDvstd68VLDQKnBVPnEK93lWM=,tag:xKKqKVCzEYlUe8LHnL6jiA==,type:bool]
-                template: ENC[AES256_GCM,data:3aIYL5nUI8R7f/Aza0aFZAExJj5OiOzhk7qRYj4SuXFUoRiC4jc=,iv:h9hOhZK097XRWax79JXuyVbZlQ1oAC64f2IsOf5TxNo=,tag:hm+9OWT/tGFTK89aZmDUJw==,type:str]
+                enabled: ENC[AES256_GCM,data:bemojQ==,iv:k7AbnUVCNoNGYuo71yfc49Gqck0FlYYAfZI2DuDSlvw=,tag:yxRX23qARVbsbMEoQgRNVQ==,type:bool]
+                template: ENC[AES256_GCM,data:hckcy8b+4WvnAYmxz9DcqxNabDgANzMbc0YcWdqMuLf8eLn38Zs=,iv:Mf2ITBAU+K2XWHHyh6fLOw36S6j0uvWlLcNLbmJX7T0=,tag:0z8Rj1AH2js0PeUbaed2PQ==,type:str]
             oauth:
-                enabled: ENC[AES256_GCM,data:UsZWeA==,iv:g9f1jYw1cc1oamzVyw6EpHzq2KYNSqaCJOQJYLkOO+A=,tag:SkQ3xViaLVoKiEtT+mmjRw==,type:bool]
-                issuerUrl: ENC[AES256_GCM,data:bDdnrq0nOPbBnaWupX3A/9+syFB03bQCKOycrn3NtDkm1wACK5uHopPDoRxGdWQO3wlj+y7wqOJqPD0=,iv:MAPU/QsttxacNBM7p1kzReeMpOmjTzvs5dvGXFIM1yM=,tag:wnPrFi4xEZ+58+jPXJuSPg==,type:str]
-                autoRegister: ENC[AES256_GCM,data:HvNvwA==,iv:oTuBGkQu1nZctF5W/9c5VB6tLmaY5fdbFkpBPd1Qg8c=,tag:jK9A/V96mWul/RuMVAwe3w==,type:bool]
-                clientId: ENC[AES256_GCM,data:Nb5CEG2w+nPNPcWL7jW1tzboa7q03bjuNyPtVpZUVpggBnts,iv:30zIxRGJyuXjY0LAZ9KUKmkWsXeIzDlDT6kpUv551aY=,tag:gqHara0lNX3lGksfzYw9DA==,type:str]
-                clientSecret: ENC[AES256_GCM,data:/Y8zRn540jRaAD4ZDtWTDXfeuAjbS5EOoFlABNa7fH0=,iv:39bausN1GPDo6c3cVBGgdAAneRSLdbC0W7UGdQ4Idbc=,tag:1bVFLymw2OTtBEa5D8pqhA==,type:str]
-                storageLabelClaim: ENC[AES256_GCM,data:G+faGmutQhSXwgfPqAwMYYYL,iv:luqM1qSbvxVKtFReLDeQBRKPa9ZKBbTMdWUFmH4/JZk=,tag:3cjSZAzG3OuwNMNE3+sjZg==,type:str]
-                buttonText: ENC[AES256_GCM,data:PiXEHxM41luWmQeS5ORYQpBndbg=,iv:zq/fsBEOYSxde9Zlx8vjGi67jmekQQnPaBu6WQpV/Ms=,tag:IY1Et10pN+XEJAr+4ZeSTA==,type:str]
+                enabled: ENC[AES256_GCM,data:iteHmQ==,iv:VvhE0WgYQytww3hjWgOUZUsCFuoKobE4n1P8r/p+eEc=,tag:Y9DCwdJzKN9fs6kPX1VwXg==,type:bool]
+                issuerUrl: ENC[AES256_GCM,data:pW356ali50abWI8Q//JJ6lH/kqyS4getCbiSdbfFBsrfUsTj/6cmFOJAagNDJt29tqUBR6MTxh9ll98=,iv:XJWIMSTNqgXVB5NmFDqH3X8+/zTXQYRgumjAaf9ZkmQ=,tag:6FmQwldva8rA877tRpugSQ==,type:str]
+                autoRegister: ENC[AES256_GCM,data:Mb7jlg==,iv:V4PY8n/FwG4xs2qzrM9N/DUeT/mrzX8LkXIxtoWAQ84=,tag:PsciWhBIjW1UWCaRCEZhHA==,type:bool]
+                clientId: ENC[AES256_GCM,data:COixcCJiEvAEQF6+7WvYkGRXUJieTIUAZhcEwEOXnddSdR4L,iv:Tkkg+IfGoqgA6heLIkbbYuW1VKzPHT0CH6tDdpDC/NY=,tag:fQrnk8OeU0xZQPimUwNxeA==,type:str]
+                clientSecret: ENC[AES256_GCM,data:dNRjD6pje0LzIQlsEUeG0O97NIlN9woPMzep+/9+d5Y=,iv:EnNEW2+/MF+Vr37wDTbaybo343tpw6pM+vdMDipnoTo=,tag:JA/fd0DfjE69YzIYFww1/g==,type:str]
+                storageLabelClaim: ENC[AES256_GCM,data:TgzJHu7liiMPDmPLO2k1tEE/,iv:oUbQG4FvnKgvNFlF3Ky7mtWw/dQusOtQrEHcEyff2vo=,tag:SR1FRdOIHZtrUnABPTGHMg==,type:str]
+                buttonText: ENC[AES256_GCM,data:udg36/2LFYXDOW1eTOoMU4VE+F4=,iv:UOh96QfNHVB1Rg4aWRswIj1Iijo2Pmy0fbC/4iMrHUY=,tag:3jcIo/BOaR+hYQMvf1lmog==,type:str]
             trash:
-                enabled: ENC[AES256_GCM,data:XdZLAQ==,iv:MUnUirm0UWtChGnDkctOHaT0xuvZ+u8RnQR67MTHL/c=,tag:a227hIlGrHXTYFIas1UuYw==,type:bool]
-                days: ENC[AES256_GCM,data:X5Y=,iv:2UMVGAI/R2A8lMreH/CgB43qP8sSh8ClJBN39aCqcKo=,tag:BYbxr2tKWiikYzGlbt9hjw==,type:int]
+                enabled: ENC[AES256_GCM,data:LrCUiA==,iv:TibS6UqG0nQ+Gu+bCBYqJX/SS3JRYUczCpUfCutuNMA=,tag:T+wQ6yGcHbr9Sceq1nCvYQ==,type:bool]
+                days: ENC[AES256_GCM,data:cWs=,iv:+xOh5jurWqOSNZuAOQAqwFYtxhwHqEiueenZGyndVMc=,tag:vAszDkcWtvRVpDsY9woauQ==,type:int]
             machineLearning:
                 clip:
-                    modelName: ENC[AES256_GCM,data:vdtrJILDRkDI5qAEV+O6Mw==,iv:cCecuOdCoV4ZbLR0aCbHrBJMs+bCnNPCyb3Mob/KtKY=,tag:HoEKoeQg+ZXf1E7ZSjkAUg==,type:str]
+                    modelName: ENC[AES256_GCM,data:NuZH1f/NnsEQCAIVvpNC7w==,iv:uoEGv+nT+BpDatb6b5g2To3OGPibd3BOvbnJz7pB030=,tag:4rhEm8IXO0QyWs8ZPQOSVA==,type:str]
         persistence:
-            #ENC[AES256_GCM,data:WYtRlQs37JeL8Q/IZoaLSMcFhxYDZ9YEnMdcowvuB5pedjebeAqpjrzH//B4UKMOY3HPvwV1I493Du22B54i9kfO1ts=,iv:s7yQ80sf8UZf/T7eDC1R3Brg34Pe08AItnOxEz7K8wc=,tag:jYbEQG0q1Kizs2lSWuXjfQ==,type:comment]
+            #ENC[AES256_GCM,data:GLmyDCl0YvQM4NmahTng0gXAKGjY0AYBl7DbYWk4tMWOwHMULLdW2JtDPNXjmOxyHLuhfjEZJbaeDGvS3kfaegLU2n8=,iv:BQdut0Pe7iD1D3hnQLqBgm2oHPFAz5Lxy1I1s8n5FWc=,tag:XQKUfmC4lFbN5iHHQEmdFw==,type:comment]
             library:
-                #ENC[AES256_GCM,data:AVTgWGPdeJcexRbM/kluxQtKweoyEt9wt7z8PCuf3K47pVWghUBXEe07ySLM4WclZzEba3ahE1MN5tTkH0dxKzL1w/YWSR+Thw==,iv:e22bhloWOYiAKEll78bf3yEfX8w0rB1+YjxZBOneUww=,tag:ldhTRtrROjKao/KkW+KBAg==,type:comment]
-                #ENC[AES256_GCM,data:NND0CkGGdmXKtXQmx1/JuELC3pCKMP5BdTHWMVbNMAvzwaQC5hloSArq4w==,iv:aqZheKhm+3YfSmTAQds3e+lzc4S2JMkn7r+6A+AccF4=,tag:ngxsPtcz98LUUkdxjwpxDw==,type:comment]
-                existingClaim: ENC[AES256_GCM,data:h+DsWJRkSA==,iv:9ARmDM2vlZDCV2n3a1K2VJji3ASOfsiNXvpHmcv7ptM=,tag:S4Q28TyH9Fh0BmP6SNUYng==,type:str]
+                #ENC[AES256_GCM,data:OKtjiAdXbMUhxtOO5tFGhtojDKa71uhyuSd3CHYuAlnBgYeYDqVCfxXLxRCvkOwvLrHDpAx8TlzdrsiWFTatRavwkLuYxJ5lqg==,iv:YL/Hm+L7tU807FZNYweAu/sHlxllEnmvavSFRaOvvkI=,tag:J/5EphiwbyOmKC2NsbWNZw==,type:comment]
+                #ENC[AES256_GCM,data:LcsIh/ZRccj+LDCAG9fsY+aSIBzvCLAXrMlYcq4PdwdKJ4U1YA5SmCKgYA==,iv:Y8BNNt4DJjuheoeaFbXaa8ypCf5bwCdwWu27zmalOq4=,tag:aUTRZq9DZ3hmfldT/ygW5Q==,type:comment]
+                existingClaim: ENC[AES256_GCM,data:GlMXz501qw==,iv:t2+ezyx24HnuBlPspIlfNvJsk+Lm9wLikZ+MQkwWzj4=,tag:q+85rWXdz5VW9ajBjzGbAw==,type:str]
     server:
         ingress:
             main:
-                enabled: ENC[AES256_GCM,data:+Nzh4w==,iv:57sPuYhlHDSwC4uY1/sDkofOG2c2ru4+uoTPyvezmUU=,tag:2KOIfcCmlnu4NUGfozO8ng==,type:bool]
+                enabled: ENC[AES256_GCM,data:75ARRQ==,iv:aIKbkXAXMklCYkO5dYM8bUTcwbM/z7TUMwfhgH84ZoA=,tag:YotEScRXGrrYk5qqLkhWDg==,type:bool]
                 annotations:
-                    cert-manager.io/cluster-issuer: ENC[AES256_GCM,data:w8KK4xQT7KwSflVeqVvm7A==,iv:FLQFXuw/OTLfoAm7VPitA5/lDzAEqLKji8AZCMK/AGs=,tag:2xRkKCYhffhJUAZwJchV8g==,type:str]
-                    gethomepage.dev/name: ENC[AES256_GCM,data:3SVcQKVt,iv:/6on9YeHgSHetOlTyX1HYr+W2Vjbv5CRHBHKRjPngQo=,tag:E+4tqDkdiOyuFC3tTj/5XQ==,type:str]
-                    gethomepage.dev/description: ENC[AES256_GCM,data:DAPra+WlRWCC3jcuNkvljcvXG+q6Uw==,iv:M/XuR1q0ocvyIvaUks1ABpS7+KuJoC1sPAFhLRdP53c=,tag:AfNBfSIQhvWrtbOEYzzJUg==,type:str]
-                    gethomepage.dev/enabled: ENC[AES256_GCM,data:m/pE0A==,iv:qjKo6YAbhr0tQEhTLGQ4u3Ugj/YBpVLcxSFieiWn/bg=,tag:Apb4m33KZQJhgkJeuHxkuA==,type:str]
-                    gethomepage.dev/group: ENC[AES256_GCM,data:HInZvQ31jyzi,iv:eLLgwJgh6vrwEtifbvph003apbgSaTQ6mP3lZANEUoI=,tag:E9xZvSkTW++J/yvQFFm6qQ==,type:str]
-                    gethomepage.dev/icon: ENC[AES256_GCM,data:6l2sj96jZHgCIR+Hew==,iv:/ckvoKXhp72Wlt6Sw0+bdl1V+Wfjf1xoxMm5cIW/kXs=,tag:QIduj4oHjqng1FDZ/LW7cw==,type:str]
+                    cert-manager.io/cluster-issuer: ENC[AES256_GCM,data:biY3zOs/H3w3PkYxnsxqhw==,iv:jfO0kb1xZG+/yqFQZggBp3S971bYnBvVK4k4Lhc36zg=,tag:P1QAQDSyQ+mxJxjAJSTvAQ==,type:str]
+                    gethomepage.dev/name: ENC[AES256_GCM,data:m9M86u3X,iv:slKOOZBKjUNRP+dmEhxhaaCTkw/PU6IJh2cK2Le2DGM=,tag:pbwdqYBxmuQnZtGoWlPD5w==,type:str]
+                    gethomepage.dev/description: ENC[AES256_GCM,data:FpbQGnFJH1UR046l8x2W8CTyKUfowg==,iv:dMg/mwv2PJfmG26CM252miQIZ1owqVDCuXUo8tPxgvM=,tag:VLnTdO8s6byT82sMBZIhbA==,type:str]
+                    gethomepage.dev/enabled: ENC[AES256_GCM,data:9/KPbQ==,iv:5HkFYhTJvENemI5cwTEqFZwRDZ855krj+oNpVnVIAE8=,tag:JsvgOLPzIY5aNFDZyLDngg==,type:str]
+                    gethomepage.dev/group: ENC[AES256_GCM,data:CZe2y3Ew/JMe,iv:qkeYVTQsOcEtzx0rDsNHxxvbZyr28gXHO41d7mnCKFQ=,tag:jHH9HNmO1TzmDCVOPQ50Fw==,type:str]
+                    gethomepage.dev/icon: ENC[AES256_GCM,data:YyBDxK54mjbmQHfKaQ==,iv:0Ma87iY6HTbN+vusvzxXe3+HvfDhWf7s7GkH1HPzzbY=,tag:mNR8BQfUGiS6Mzd+ox7fbQ==,type:str]
                     gethomepage.dev/pod-selector: ""
-                    gethomepage.dev/weight: ENC[AES256_GCM,data:og==,iv:bls/IWFSQbpsLM1GrWzDKuFzWxqmR51ETE2BQmpbiDI=,tag:LeglmyLYb3YkEcLeSzGn6g==,type:str]
-                    gethomepage.dev/widget.type: ENC[AES256_GCM,data:m8M0V6Iw,iv:gm5dxUPxRxO8udDm/akmWdbHQxz5y8eECu8q5JDUO1c=,tag:YNa0POzBCjiRPUCtekg7+Q==,type:str]
-                    gethomepage.dev/widget.url: ENC[AES256_GCM,data:1E0g6H4vHoxrSEz9l/Dsnr6YwqqmFEczJiKClWOXKDXYyI3m,iv:N4/1PTfvSEvmqqBIGoYOYmxdM7nGJe6T3cRFXBEeDIU=,tag:2FYxFrtBwSL3hbI6DOWnjA==,type:str]
-                    gethomepage.dev/widget.key: ENC[AES256_GCM,data:jVLZOlo2l8L7w9E0TZuu/ORKITcqJM7SlVC/uBT0qPpucobALV8Ab5i1,iv:agnWXXIFMWNIPp5mf3ki8HjHD6X+YogYMrDwZgMaMpc=,tag:p0CFZxyFw/NFlcTR9+I2wQ==,type:str]
-                    gethomepage.dev/widget.version: ENC[AES256_GCM,data:5w==,iv:Sd3Y8NrtEjmYDrPYo92YdEXR0LZ3MjdXLvaX415X23g=,tag:k5A/+w1Lu+70JikJSBC5gQ==,type:str]
+                    gethomepage.dev/weight: ENC[AES256_GCM,data:OA==,iv:bB51U0moPe1dlS+0GH8101mNnC97W2t0Erm25AqtY4Q=,tag:El13hiepDuVyCPRlHlEVnQ==,type:str]
+                    gethomepage.dev/widget.type: ENC[AES256_GCM,data:euHyg0hV,iv:2B03lWhloK+yIVfFKrcW/1xbu73XAOXwI/nQDDQo3gM=,tag:VPyUJ5r988k0Y8HjUrSgAg==,type:str]
+                    gethomepage.dev/widget.url: ENC[AES256_GCM,data:FuyCWEH6fMFkNLL+lWZLNuk6QP7v+8+iY5SLbGvJRHKrr6xG,iv:tOmUlZCthTVsm1/jrws5kp6h4yAFFoTMdKWGkiBYdBE=,tag:CLrTDH+Za8a8FsTJhrqYcQ==,type:str]
+                    gethomepage.dev/widget.key: ENC[AES256_GCM,data:O2GpS6gpaywZSnyZFmjqHKV+/i7a4i+KoHDhcBZt1XpAtYUcgT39rufC,iv:lm+ASarJHu/3icCHo6m4tUZetkU5E3oAaym5bnfUyxM=,tag:QyJY1NdimYSNhx66HJbyLg==,type:str]
+                    gethomepage.dev/widget.version: ENC[AES256_GCM,data:dQ==,iv:s7wuuqKUbfXwL5UNL1GnXd6pzImfsEJGyJ6G4hpmGvY=,tag:kS6oBHrCl8pMZeOVt+2++g==,type:str]
+                    traefik.ingress.kubernetes.io/router.middlewares: ENC[AES256_GCM,data:2DKOHk4GwqA0rel2lJS5l4Z4G8aTLSj2qWfeH8GeKDXwmh/rb3LsjYg=,iv:wFEQEyvu/bn7oKeSy9nTJxok27V+Slsa/ANfUljNlqs=,tag:sqMouazS37ivXg78yMjQsg==,type:str]
                 hosts:
-                    - host: ENC[AES256_GCM,data:C+97MNAdRZZmx6ovtO0+fvex,iv:axuZW/0+LxALdf1BT7Ul+y7gUzfgfXOy4Jm/QfAt3WQ=,tag:lfpdsIEBflz0vuL4n4cpAg==,type:str]
+                    - host: ENC[AES256_GCM,data:WVgvNmSw8NR5Fj/6jemFST1J,iv:rJwHD9B9ff/Mn/yxTsP8N7rN9e3PwAStfeLuSLl5nFA=,tag:JZdnkrTJhjcVnPOcwJCo4g==,type:str]
                       paths:
-                        - path: ENC[AES256_GCM,data:jA==,iv:jXEqZS/BHrvq96xdme4YUJpkOgSedXrSA5tXYvNJeg0=,tag:Ps+H0oVaocN+ka0ELoxuNg==,type:str]
+                        - path: ENC[AES256_GCM,data:jQ==,iv:16RBDfK2NbM0tQpOAV1ThuUSVmmAHrD5dQjLTh1p1Tc=,tag:gTu76tExo402Z0dbXmKOWA==,type:str]
                           service:
-                            identifier: ENC[AES256_GCM,data:plQXEg==,iv:k8yTh2dMbUVTO4c1erstzxv/ISqZhrpdR/e5Sv8lstU=,tag:5ZkR2ajT9rFlH3szoGBrEQ==,type:str]
+                            identifier: ENC[AES256_GCM,data:VkC3ng==,iv:bT5zNDLOuJvkWXuclB+CtjYuQYp3pg+TOTiIFJHRk98=,tag:+8XjTQA/z4hGdEIPyaSvLw==,type:str]
                 tls:
-                    - secretName: ENC[AES256_GCM,data:pGpTMGLf1OMXjpD5gTGG,iv:7F3HkP+6VXb7SXDefb0mr+NYJmrFKOyD2U/CDqAFUYQ=,tag:j++VEUuwxHDD41eum2EpqA==,type:str]
+                    - secretName: ENC[AES256_GCM,data:/19IWryJpZi9Bqlc1DsU,iv:MwCEBuV5y3ff/Gw6Y7QsWrWw4BzJOtanKwZMZ+RSSh8=,tag:o9r5mIY1BoLA8WYVdaMT0w==,type:str]
                       hosts:
-                        - ENC[AES256_GCM,data:W4tGSr1RcdLDz5v1e5XEfo82,iv:dSYotu+B/SyaQ6m7OKrdEELxAIWLoKV9FcukcVnhEHg=,tag:xw4i2edkLcpzm86n+RinHQ==,type:str]
+                        - ENC[AES256_GCM,data:YvRLotLFNBZXluLpzrxIljDv,iv:fauf1JvbfJvcbKOpqsMH5P4NdUmQMtDJ7kooLy2xfHM=,tag:QY1pevHT0len+5WmgRDXuQ==,type:str]
 sops:
     age:
         - recipient: age1zkfsdxrlz4aqqd00qap7hksakc8jdkzwkmqs3p85fkw75xls6q0sy37l5g
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmb2tJaEUvVytKd0N2TEhz
-            akN1QUp2UERHQnh6bUoybVFySy9zRjhmcUFnCnEwaU51NENEMitFM2JpS1Y0cm5D
-            ZTZUUjNMSTA0UHpNckZpMTZrMFJValEKLS0tIGp2UkJnVjRLODRNZHJldTVaNWJW
-            dk9UWWRzcmk1RGowbWp0bW92VTdMZG8Kjp6LKK+vfGMrlTboQkhjj9BdBoKcClKv
-            MlWhUQYMs3COPXMR1XOzttsilUlnNWajDalJVG32Cd82wueA7CD5pw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZSXQrUy9MeTBkU09xMVQw
+            Kys3MWR1bDBFT0p1TWRMUWZSTCs1L3ZnL1N3CkxodmJCU3V2RWRHLzNDeGM2Nlpa
+            dkZrZkhXdkRvUlRjS05hZlpqcmhmYVkKLS0tIEk0WktNQjRidjkvOCswZlRxMWhm
+            ZTdPeEp4TUZQZFdtMDhxVlZvQzNnMUUKDBvFCRPU9iWkJlFdRsU73Icqj1smIloW
+            btH/Yj1cNrg2JzXXAcg0m3qOo+e+TLmf3kA/yQcysLob8Fbayh37XA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T21:32:41Z"
-    mac: ENC[AES256_GCM,data:S9xxWIPbfO3PV7T7hXHykrLlVXTDl6tQGZm+gGPta0XeKLhonD4ufIVf/stquYcBmlT6X64l7NVfSb4OEUP3WE8Q4/4wmoUHLWtVhv8UUIEIQ/fB+V9qQ+KVJNG95gur50qMUBM5op4TFgjSLB/rm+MsK/nAr7pL/SLwTVCbAXM=,iv:xpW3G/zGHUn7Qnnb7pcWXdFSJqLYZF3dwWwrBFZBaow=,tag:6jwi2BU08nMIh8NkDAV8Jg==,type:str]
+    lastmodified: "2026-06-01T13:08:34Z"
+    mac: ENC[AES256_GCM,data:n/1Pee4qxc3NIIYKVwOamzUc57kZrzlULWtG6YGAveCmbHAygsP68EsnJN5GutG9F7UIxB03bZH7zM8phK5vHBgnSB/n9x5fVL9myJB+cupab19s9KoyTuIEpqo+zs9a+9KJzxpCJ4OC2U1NYU3Bt1t8JXJ0+0QBlmx/S48AINs=,iv:EuX+hWQ/9XoWe6q2cfjKKk1LZIZK1ZuvaqGHILyv0BY=,tag:VkddI74djsqosC+v7Qc44Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/k8s/apps/immich/values.yaml
+++ b/k8s/apps/immich/values.yaml
@@ -29,10 +29,6 @@ immich:
       enabled: true
 
   server:
-    service:
-      main:
-        type: LoadBalancer
-        loadBalancerIP: 192.168.10.207
     controllers:
       main:
         replicas: 2

--- a/k8s/apps/koffan/secrets.yaml
+++ b/k8s/apps/koffan/secrets.yaml
@@ -4,45 +4,45 @@ app-template:
             containers:
                 app:
                     env:
-                        APP_ENV: ENC[AES256_GCM,data:49UzvjnXRfRMNQ==,iv:BoynTYL9tZmnCU3ZUMLDSz7AfEsmZaj3arRpqwmf6WA=,tag:VsJLaMq08T3fZsrON6IX7w==,type:str]
-                        DISABLE_AUTH: ENC[AES256_GCM,data:vNin8g==,iv:nYovXJ1gK7kryWkFO/BYu+6GEJ0AWd/vjBAmeYKCakI=,tag:I+uXrrWh+RxBE19VhNYL0A==,type:str]
+                        APP_ENV: ENC[AES256_GCM,data:c5QlW91Qlw0s7A==,iv:jLVb4PlfoKUCYk3GWP2laePQ034ACB8oKF3wKlZDUzo=,tag:NrmbxgZbcZTNXEOpBirU4A==,type:str]
+                        DISABLE_AUTH: ENC[AES256_GCM,data:C5Iw9Q==,iv:U4jUIb9jHyxVo7IP6V8W9HIfky9ADblMGxKfIE8oC/A=,tag:G81BWPdILgb8u8iDJv7PGQ==,type:str]
     ingress:
         app:
-            enabled: ENC[AES256_GCM,data:HabmEQ==,iv:6vUOAxkTd8qqy/OU1h3iUydCeqz/tJ6YNJyWlmpoWfY=,tag:32HgViws4UIeYI2Azqksqg==,type:bool]
-            className: ENC[AES256_GCM,data:0y7edq4xlw==,iv:A+9EgxoiwdWk0mylAc0Wz6DybKw1DZ5rQBlkuBuThY0=,tag:RukaAHMCXngdEyP8gA1N1A==,type:str]
+            enabled: ENC[AES256_GCM,data:CSJQ2w==,iv:zlmEXNUpgBWyzgLZXB93RtMQHjX9SWSfddhRkAeSpEM=,tag:hKjW1rn9+iP6Irk/Z1YAbQ==,type:bool]
+            className: ENC[AES256_GCM,data:sYQ6R9/0IQ==,iv:BBsB2wacVHCgkEh31jGpGnIkylcb/mCtWI+IknmbITQ=,tag:O+ylTimYVnCuOO0QLeImQw==,type:str]
             annotations:
-                cert-manager.io/cluster-issuer: ENC[AES256_GCM,data:r3RBGZYgJA/q2Umq3ybqJQ==,iv:O8kZD7J+JD7JbrwRfUZhErSK351MXNiREvEc85ayLyc=,tag:qpL0B4iuQdvnB6EF+QLRhA==,type:str]
-                gethomepage.dev/enabled: ENC[AES256_GCM,data:w7e91w==,iv:2EikfLhTcJIXXhxQRo/KAuxVfu5h78vSC+4xochSZWY=,tag:3kezMPma4X7u7kKEMHfDuw==,type:str]
-                gethomepage.dev/name: ENC[AES256_GCM,data:VI5EPud6,iv:fNAjSo/27U4ds5tt71pba5hXiGN2Tu+1t8J2WmI5AMs=,tag:jyoy9N4qZY/Hl7ZMaLqE9w==,type:str]
-                gethomepage.dev/description: ENC[AES256_GCM,data:KxpD+devmv3CVc4pv9xv,iv:wXgsDv/RXouU5turEireXwGRGrAxUahg+WURGk5FX7c=,tag:nzqtWPKmaVNK+PQDBuWotg==,type:str]
-                gethomepage.dev/group: ENC[AES256_GCM,data:mj/OrXVylK6l,iv:NwMmu+ZtE0b1rO6NtTmdVJWCip02JPpxUFdfirJEQQ4=,tag:V77pBsgzKDZFDDlj8ImzIA==,type:str]
-                gethomepage.dev/icon: ENC[AES256_GCM,data:USL86zFZ4BXy3BokTQ==,iv:RqKbA+8AOFHKtE0GBQf4KRHjIBwLs+KIKW0DfAiO+qM=,tag:33MVJFI9gl3LcV1L+MYM8w==,type:str]
-                traefik.ingress.kubernetes.io/router.middlewares: ENC[AES256_GCM,data:m5HseXYJEr8ZI1UKLdKI0fUnHKci7L8h5NhqWmRDjRdtigNSN7m3+sUkvA==,iv:M/l3FyAjczIsPTIuJhlzrtloojLvzfcZc+vATibZbIA=,tag:Y8WnwoG1ktI4bNAk+hT0wA==,type:str]
-                gethomepage.dev/weight: ENC[AES256_GCM,data:lg==,iv:AXHgaTZK5dslXgjhSny71Po5X/yr1bZmljLf9SbsdSc=,tag:gKeZvNQfg16+SFJUdh0+cw==,type:str]
+                cert-manager.io/cluster-issuer: ENC[AES256_GCM,data:CtLGysR4uV7k2UY/7o0JjA==,iv:MJaf73D5jZ/GEqMnOOKNUse2HEpvqOcxjLu38xKCC/w=,tag:2AYGJHHWVkH+nJ9RdHQwsg==,type:str]
+                gethomepage.dev/enabled: ENC[AES256_GCM,data:lImN5A==,iv:3E7b8z4H1Iy9C2TramgX+gJF/OBq26w+ED97An3/oKQ=,tag:ONbV7pU4GS76tI5srCrx8A==,type:str]
+                gethomepage.dev/name: ENC[AES256_GCM,data:PIkKXPuv,iv:Lmsss9MvcP2PQ8RW8kgSa+xSOJozt25FjZPjyO4UDJ0=,tag:fYGxjQb4CgrBI2wWpsTc5g==,type:str]
+                gethomepage.dev/description: ENC[AES256_GCM,data:UfHT6GIDHq/x5mgeLPeU,iv:5B7yk43xsjsV/7ltv+CzOBgczl/s1DqtfHHF2HJn+4A=,tag:OKSETIkONlJ30qohY68y7A==,type:str]
+                gethomepage.dev/group: ENC[AES256_GCM,data:sgOjMpLR9QB/,iv:77sk0ETvcS5Q0GTd9YRs22RUce2qkZ3jkE9Q0yuF/HE=,tag:6WkC8g9/XOKnTRT52aRAfg==,type:str]
+                gethomepage.dev/icon: ENC[AES256_GCM,data:NcxK/uLZmkEISOEXyQ==,iv:80ZYkbFNJwW1EHrXOplUvJ9JIIeyuoTTZf4MC9IzRW4=,tag:DKcP5X8RvOAiwFaMw5pOdw==,type:str]
+                traefik.ingress.kubernetes.io/router.middlewares: ENC[AES256_GCM,data:amCBsYtdwRDHt6ii1jprSuJHyPjuxG01AJyvhcvdkYtyKnoJ4Pgkrz+lKp4HQZJ+rLI2hW2vbsvedzhIar/ryCLpJjfx9z77s9fYql5Uoi9HY1MCNg==,iv:HkvCOWQQn7vV5wMZbCy3+r1TvtJdhsq7/9N8f3+ILCw=,tag:kBmCm7Z5FUJDVpK4kpXOzA==,type:str]
+                gethomepage.dev/weight: ENC[AES256_GCM,data:2Q==,iv:1UDhyhDVI2u4vTbCNvGL6aS1zqhiVyFj1w3mTeUAzw8=,tag:VUD4Ra3PJJVhT5PtHeekvg==,type:str]
             hosts:
-                - host: ENC[AES256_GCM,data:11mIbqLUTwu4cfwxnClBjVUs,iv:x6Vrhgjp0Qh/95VLhzJUEKI0q6VBZk3P23tsKqIIvhU=,tag:NancvSnviaBsw8ghaRq5mw==,type:str]
+                - host: ENC[AES256_GCM,data:IOVZ8ecStndvvhZJBf8L2BVh,iv:XVZEl8QNu/YTVaKnEEvZuQCw0yOwGLF+9XQPJCDbTCI=,tag:xvQeXKLwgOPkwBtvjd01CA==,type:str]
                   paths:
-                    - path: ENC[AES256_GCM,data:4A==,iv:9VfQZMsMwadfB3ENrXDLDF3RSpO0Pam0JMjTtTQYvFI=,tag:fBMJ8K6GoIPqDXvaq0pSfw==,type:str]
-                      pathType: ENC[AES256_GCM,data:68dxykyT,iv:IpexRFAtLcgOQZ5bWoBcyhy7FPlDqzTas/PDJa66XaE=,tag:63IkEEBKtRWHbuVx/yDIKQ==,type:str]
+                    - path: ENC[AES256_GCM,data:gg==,iv:FBQXcbaaqnRXwpTLrGh/qibK9SYUoi5QgI2PFRkl6EY=,tag:+CWaWeXGwC9+28yZjGZVZg==,type:str]
+                      pathType: ENC[AES256_GCM,data:9uTMdzHz,iv:Fb1ysE2rzNiYaw0d0XjttE8Jx1z8sXWeqtxXUN28MYk=,tag:JAyC6JUIwdsj0MUF7xvqJQ==,type:str]
                       service:
-                        identifier: ENC[AES256_GCM,data:xG4Z,iv:z1f55Py2fonoY/xAUr0/Z2lLkCVYYZsrfToeE+LUavY=,tag:NDX58nMroeN8s8rsFM3gUA==,type:str]
-                        port: ENC[AES256_GCM,data:YDJrww==,iv:/xA36XBgv/hth6tbsLvQD82GF/l+/hSAKNGD0MTCVmM=,tag:XXUMYiqdiPDSssJU+yY2Lw==,type:str]
+                        identifier: ENC[AES256_GCM,data:cjWe,iv:Ra1YEjAhdqS5Nm5DTZb+e8n/SP8g68qfWygU1Ahjiz4=,tag:cL3H/6aZFjB/1LLTBf1WLw==,type:str]
+                        port: ENC[AES256_GCM,data:5EgpWA==,iv:7HWif7HYyQBUzisH9TgtBK7gIgdzLuRrnmeqlwRnBHE=,tag:hJl+ENaBJuAj4JYMQREbvA==,type:str]
             tls:
-                - secretName: ENC[AES256_GCM,data:pndxDY33owjvWdGXTUl9,iv:s16FEtH7dd50LuCEJcmOgCZ19gAN6W0W8pdACyPmP+s=,tag:OkiEgkxXP3qN/U0HuefxDw==,type:str]
+                - secretName: ENC[AES256_GCM,data:d5MJUMTbhf7oYrrZlA0R,iv:8edNLvMGsb9Xpe7r9TpIr8V4UfjjdlCkWEVoSNYy2u4=,tag:rCgG3UR9nexLfMx6JwgwRA==,type:str]
                   hosts:
-                    - ENC[AES256_GCM,data:+a/GkyX4ZtCsUpB90t0S5k1A,iv:t/q1xdnH2ulWD9ZbOlBYJxsMuoWhzaknPW2HlO7Vwf0=,tag:ZpN2idKaoDrRFSSGdh6Llg==,type:str]
+                    - ENC[AES256_GCM,data:Asb8mlHJbtJl1eNqXvQmNwnJ,iv:j1MpicEUaCt/YtxEk0nltH5gtwGrmjLHhh54F6u0klQ=,tag:yH5ngaIt5buQRrnVHfTnvA==,type:str]
 sops:
     age:
         - recipient: age1zkfsdxrlz4aqqd00qap7hksakc8jdkzwkmqs3p85fkw75xls6q0sy37l5g
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMUXo4cHp6YThVYzdsckhS
-            WWpvWmtITXUrOE1JejFaWldxYmxUNDM0S3lrCkdhZENCak00YmNzSjBRU2hCMUFk
-            eHd0V0srUGN4ZmJ4bDBLMkJBcURtYnMKLS0tIE5xQk9oSlB4UDJvbmI0QjM2ejl0
-            eU1Xb3pKN0p5OHhvcG5xdzVNMURWM2cKp07Rh7nc4ikgSmDwE0eH8e7aFq8FBMzh
-            dYiYlzfiNT2rHeVew9p91E7HrRMy8B2v4/BX45I2s/LnzuuG5uUr6Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrZncvYmVsRkY0RDhOYTRM
+            SnhhL0p2cktZeDB0K2VHVzZtdVVKQ25nOTNRCmJ1TG5PU0xmcE1CMzZJT3hGZUxr
+            cUl1UFVRTDZyRExuRWI1WnJNZ3YycU0KLS0tIE9GSDA5QzJpU3BNMllXcEh5b1pV
+            eEt1aGlXd1F5OXhhdkhOdW9qUnpNWEkKv+QtagF04CUQ3mXbNxrUaRgrIGqKryPW
+            jSQsWVMHvDC3WeOSw0yqzQS2AnKwyusy8NBX+fpK+jc/dmFEQQb2bg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-25T20:42:20Z"
-    mac: ENC[AES256_GCM,data:JCuDEuGwERq82QuTUt2HunjhGpHKCy25p1/m5ZH3nN1B5SAaNUXAlpKPtln21Sbcm7u+h3u4/Z5EIvi/U9faX8GZGSeRwj2XXxmtkBV9TM6qkNONcFuSGCllwY5hCWuOAMBWegpkRQs0GYRG9BmRCtrB0pGC+OKGz9gST2xwWU4=,iv:Qh/eCscnP6lDr+xYKNvIuUnLI/PIw61LSOniA++GecM=,tag:csInQUFGXYYWHcaEkZtI6g==,type:str]
+    lastmodified: "2026-06-01T13:07:57Z"
+    mac: ENC[AES256_GCM,data:itexgboM1nVnRxejsgjGkvTgBRGL28s67MHPrvWRhnfS68/NRmLjqhfrJAZFeoDRnMU+vPtq3ElSlDZlfIh1qppINGPDjegc8SatIz2OPQq+FOscDsOe6s29xFhITjt0cGTuTVcaOaAMvj/octMxWW6EZgnW3WIoeS9ZBBlcpCQ=,iv:rO2u/6DCflJklXDmzdB2PRDYlRY07axa68p4nJQ6AoE=,tag:aC3uZhOe90peHoZuu7MKsQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
Apply request body limit middleware (10GB) to Immich and Koffan, and update Immich deployment settings.

## Details
- **Koffan**:
  - Added the `kube-system-body-limit-10gb@kubernetescrd` middleware to the Ingress router middlewares annotation.
- **Immich**:
  - Added the `kube-system-body-limit-10gb@kubernetescrd` middleware to the Ingress router middlewares annotation.
  - Reduced Immich server replicas to 2.
  - Removed deprecated `LoadBalancer` service configuration (migrated fully to Ingress).
- All secrets files have been encrypted using SOPS.