### PR TITLE
✨ feat(ansible): install CSI snapshotter using Kustomize in longhorn bootstrap role

### DIFF
--- a/k8s/bootstrap/roles/longhorn/defaults/main.yml
+++ b/k8s/bootstrap/roles/longhorn/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+csi_snapshotter_version: v8.5.0

--- a/k8s/bootstrap/roles/longhorn/tasks/main.yml
+++ b/k8s/bootstrap/roles/longhorn/tasks/main.yml
@@ -16,3 +16,16 @@
     values_files:
       - charts/longhorn-system/values.yaml
     wait: true
+
+- name: Apply CSI Snapshotter CRDs via Kustomize
+  when: not ansible_check_mode
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('kubernetes.core.kustomize', dir='https://github.com/kubernetes-csi/external-snapshotter//client/config/crd?ref=' ~ csi_snapshotter_version) }}"
+
+- name: Apply CSI Snapshotter Controller Deployment and RBAC via Kustomize
+  when: not ansible_check_mode
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('kubernetes.core.kustomize', dir='https://github.com/kubernetes-csi/external-snapshotter//deploy/kubernetes/snapshot-controller?ref=' ~ csi_snapshotter_version) }}"
+    namespace: kube-system


### PR DESCRIPTION
## Summary
Deploy the Kubernetes CSI Snapshotter (CRDs and Controller) via Ansible using Kustomize in the Longhorn bootstrap role.

## Details
- **What was changed**:
  - Created `k8s/bootstrap/roles/longhorn/defaults/main.yml` with `csi_snapshotter_version: v8.5.0` default variable.
  - Modified `k8s/bootstrap/roles/longhorn/tasks/main.yml` to apply the CSI Snapshotter CRDs and Deployment/RBAC using Ansible's `kubernetes.core.kustomize` lookup.
- **Why it was changed**: To install the CSI Snapshotter (a dependency of Longhorn volume backups/snapshots) automatically as part of the bootstrap Ansible playbook execution. Using Kustomize matches the official Longhorn recommendation (`kubectl create -k`).
- **Verification steps**:
  - Validated YAML formatting of all modified files.