### PR TITLE
🐛 fix(outline): force https proto via traefik middleware

### DIFF
--- a/k8s/apps/outline/templates/middleware.yaml
+++ b/k8s/apps/outline/templates/middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: force-secure
+  namespace: outline
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: https

--- a/k8s/apps/outline/values.yaml
+++ b/k8s/apps/outline/values.yaml
@@ -73,6 +73,7 @@ app-template:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-prod
+        traefik.ingress.kubernetes.io/router.middlewares: outline-force-secure@kubernetescrd
         gethomepage.dev/description: Modern Wiki
         gethomepage.dev/enabled: "true"
         gethomepage.dev/group: Knowledge


### PR DESCRIPTION
- Added Traefik Middleware to force `X-Forwarded-Proto: https` for Outline to fix secure cookie error.